### PR TITLE
Support choosing services and skipping migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,11 @@ on:
         type: 'string'
         default: '["api", "worker"]'
         required: false
+      run_migrations:
+        description: "Should migrations be run as a one-off task before deployment?"
+        type: 'boolean'
+        default: true
+        required: false
     secrets:
       aws-access-key-id:
         required: true
@@ -179,6 +184,7 @@ jobs:
 
   deploy-app-services:
     needs: [deploy-image, deploy-migrations]
+    if: ${{ inputs.run_migrations }}
     runs-on: ubuntu-latest
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,7 +184,7 @@ jobs:
           exit $CONTAINER_EXIT_CODE
 
   deploy-app-services:
-    needs: ${{ inputs.run_migrations && ["deploy-image", "deploy-migrations"] || ["deploy-image"] }}
+    needs: ${{ (inputs.run_migrations && ["deploy-image", "deploy-migrations"] || ["deploy-image"]) }}
     runs-on: ubuntu-latest
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,7 @@ jobs:
   deploy-migrations:
     needs: deploy-image
     runs-on: ubuntu-latest
+    if: ${{ inputs.run_migrations }}
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}
       SUBNET: ${{ inputs.target_subnet }}
@@ -184,7 +185,6 @@ jobs:
 
   deploy-app-services:
     needs: [deploy-image, deploy-migrations]
-    if: ${{ inputs.run_migrations }}
     runs-on: ubuntu-latest
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           LATEST=latest-${{ inputs.target_env }}
           docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST || true
           printf $IMAGE_TAG > REVISION
-          docker build --build-arg IMAGE_TAG=$IMAGE_TAG --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST .
+          docker build --build-arg IMAGE_TAG=$IMAGE_TAG --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$LATEST
           echo "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,11 @@ on:
         description: 'Unique tag for ECR image (must be the desired git sha)'
         type: 'string'
         required: true
+      service_list:
+        description: 'JSON array of services to deploy'
+        type: 'string'
+        default: '["api", "worker"]'
+        required: false
     secrets:
       aws-access-key-id:
         required: true
@@ -134,7 +139,7 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@master
         with:
           environment-variables: |
-            DD_VERSION=${{ github.sha }}
+            DD_VERSION=${{ inputs.image_sha }}
           image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
           task-definition: ${{ steps.render-migration-container-no-firelens.outputs.task-definition }}
           container-name: log_router
@@ -179,7 +184,7 @@ jobs:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}
     strategy:
       matrix:
-        service: ["api", "worker"]
+        service: ${{ fromJSON(inputs.service_list) }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,6 @@ jobs:
   deploy-migrations:
     needs: deploy-image
     runs-on: ubuntu-latest
-    if: ${{ inputs.run_migrations }}
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}
       SUBNET: ${{ inputs.target_subnet }}
@@ -129,10 +128,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Download ${{ inputs.service }}-migration-${{ inputs.target_env }} task definition
+        if: ${{ inputs.run_migrations }}
         run: |
           aws ecs describe-task-definition --task-definition ${{ inputs.service }}-migration-${{ inputs.target_env }} --query taskDefinition > migration-task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
+        if: ${{ inputs.run_migrations }}
         id: render-migration-container-no-firelens
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -141,6 +142,7 @@ jobs:
           container-name: ${{ inputs.service }}-api
 
       - name: Fill in the new version in the Amazon firelens ECS
+        if: ${{ inputs.run_migrations }}
         id: render-migration-container-no-version
         uses: aws-actions/amazon-ecs-render-task-definition@master
         with:
@@ -151,6 +153,7 @@ jobs:
           container-name: log_router
 
       - name: Fill in the new tracer version in the Amazon ECS ${{ matrix.service }} task definition
+        if: ${{ inputs.run_migrations }}
         id: render-migration-container
         uses: aws-actions/amazon-ecs-render-task-definition@master
         with:
@@ -161,12 +164,14 @@ jobs:
           image: "public.ecr.aws/datadog/agent:latest"
 
       - name: Update migration ECS task definition with latest image
+        if: ${{ inputs.run_migrations }}
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           # omitting `service` input means "just register the task definition, don't deploy"
           task-definition: ${{ steps.render-migration-container.outputs.task-definition }}
 
       - name: Run migrations in one-off ECS task
+        if: ${{ inputs.run_migrations }}
         run: |
           echo "Subnet: $SUBNET"
           echo "Security groups: $SGS"
@@ -184,7 +189,7 @@ jobs:
           exit $CONTAINER_EXIT_CODE
 
   deploy-app-services:
-    needs: ${{ (inputs.run_migrations && ["deploy-image", "deploy-migrations"] || ["deploy-image"]) }}
+    needs: [deploy-image, deploy-migrations]
     runs-on: ubuntu-latest
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,7 +184,7 @@ jobs:
           exit $CONTAINER_EXIT_CODE
 
   deploy-app-services:
-    needs: [deploy-image, deploy-migrations]
+    needs: ${{ inputs.run_migrations && ["deploy-image", "deploy-migrations"] || ["deploy-image"] }}
     runs-on: ubuntu-latest
     env:
       TARGET_CLUSTER: ${{ inputs.target_cluster }}


### PR DESCRIPTION
The default for v2.0 is to deploy two tasks, one named service-api and one named service-worker. We will allow configuration of this in v2.1. Additionally, for cases where migrations do not need to run, we will allow them to be skipped. (The job still needs to technically run, as a dependency of downstream deploys, but we skip all steps except logging into AWS, effectively making it a no-op if the boolean is set.)

Additionally, this includes "BUILDKIT_INLINE_CACHE" which can reduce image build times by 1-2 minutes. 