### PR TITLE
Update fluentbit reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           environment-variables: |
             DD_VERSION=${{ inputs.image_sha }}
-          image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+          image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.23.4"
           task-definition: ${{ steps.render-migration-container-no-firelens.outputs.task-definition }}
           container-name: log_router
 


### PR DESCRIPTION
ECS deploys are having trouble and stay stuck pending trying to roll out. 

We've seen this before - turned out to be related to fluent bit image (issue linked below). Something that seems very related - stable tag was updated 3 hours ago in ECR: https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit
https://github.com/aws/aws-for-fluent-bit/issues/348